### PR TITLE
Pusher

### DIFF
--- a/domain/BoardElements/pusher.js
+++ b/domain/BoardElements/pusher.js
@@ -2,7 +2,7 @@ function Pusher() {
 	MapItem.call(this);
 	this.type = mapItemType.boardElement;
 	this.coordinate = new Point();
-	this.size = new Size(1, 0, 0);	// size depends on the heading
+	this.size = new Size(1, 0, 1);	// size depends on the heading
 	this.heading = heading.south;
 	this.priority = { '5': true };
 	this.activePhases = {};
@@ -26,10 +26,10 @@ Pusher.prototype.setHeading = function(newHeading) {
 	this.heading = newHeading;
 	if (newHeading == heading.south || newHeading == heading.north)
 	{
-		this.size = new Size(1, 0, 0);
+		this.size = new Size(1, 0, 1);
 	}
 	else if (newHeading == heading.east || newHeading == heading.west)
 	{
-		this.size = new Size(0, 1, 0);
+		this.size = new Size(0, 1, 1);
 	}
 };

--- a/domain/BoardElements/pusher.js
+++ b/domain/BoardElements/pusher.js
@@ -5,16 +5,20 @@ function Pusher() {
 	this.size = new Size(1, 0, 0);	// size depends on the heading
 	this.heading = heading.south;
 	this.priority = { '5': true };
+	this.activePhases = {};
 }
 
-Pusher.prototype.execute = function(robot, map) {
+Pusher.prototype.execute = function(robot, map, phase) {
 	var currentCoordinate = this.coordinate;
 	
-	map.move(this, this.heading);
-	
-	if (!currentCoordinate.equals(this.coordinate))
+	if (utility.get(this.activePhases, phase) === true)
 	{
-		map.move(this, this.heading.inverse());
+		map.move(this, this.heading);
+		
+		if (!currentCoordinate.equals(this.coordinate))
+		{
+			map.move(this, this.heading.inverse());
+		}
 	}
 };
 

--- a/domain/BoardElements/pusher.js
+++ b/domain/BoardElements/pusher.js
@@ -1,0 +1,31 @@
+function Pusher() {
+	MapItem.call(this);
+	this.type = mapItemType.boardElement;
+	this.coordinate = new Point();
+	this.size = new Size(1, 0, 0);	// size depends on the heading
+	this.heading = heading.south;
+	this.priority = { '5': true };
+}
+
+Pusher.prototype.execute = function(robot, map) {
+	var currentCoordinate = this.coordinate;
+	
+	map.move(this, this.heading);
+	
+	if (!currentCoordinate.equals(this.coordinate))
+	{
+		map.move(this, this.heading.inverse());
+	}
+};
+
+Pusher.prototype.setHeading = function(newHeading) {
+	this.heading = newHeading;
+	if (newHeading == heading.south || newHeading == heading.north)
+	{
+		this.size = new Size(1, 0, 0);
+	}
+	else if (newHeading == heading.east || newHeading == heading.west)
+	{
+		this.size = new Size(0, 1, 0);
+	}
+};

--- a/domain/Common/point.js
+++ b/domain/Common/point.js
@@ -24,9 +24,9 @@ Point.prototype.equals = function(point) {
 };
 
 Point.prototype.divide = function(divisor) {
-	this.x /= divisor;
-	this.y /= divisor;
-	this.z /= divisor;
+	return new Point(this.x /= divisor
+					, this.y /= divisor
+					, this.z /= divisor);
 };
 
 Point.prototype.inverse = function() {

--- a/domain/Common/point.js
+++ b/domain/Common/point.js
@@ -24,9 +24,9 @@ Point.prototype.equals = function(point) {
 };
 
 Point.prototype.divide = function(divisor) {
-	return new Point(this.x /= divisor
-					, this.y /= divisor
-					, this.z /= divisor);
+	return new Point(this.x / divisor
+					, this.y / divisor
+					, this.z / divisor);
 };
 
 Point.prototype.inverse = function() {

--- a/domain/Common/point.js
+++ b/domain/Common/point.js
@@ -23,6 +23,12 @@ Point.prototype.equals = function(point) {
 			&& this.z == point.z);
 };
 
+Point.prototype.divide = function(divisor) {
+	this.x /= divisor;
+	this.y /= divisor;
+	this.z /= divisor;
+};
+
 Point.prototype.inverse = function() {
 	var inverse = new Point(invert(this.x), invert(this.y), invert(this.z));
 		

--- a/domain/Common/size.js
+++ b/domain/Common/size.js
@@ -1,5 +1,3 @@
 function Size(x, y, z) {
-	this.x = x;
-	this.y = y;
-	this.z = z;
+	return new Point(x, y, z);
 }

--- a/domain/map.js
+++ b/domain/map.js
@@ -18,8 +18,8 @@ Map.prototype.getBoardElements = function() {
 Map.prototype.move = function(movingItem, direction, pushed) {
 	var map = this;
 	var stop;
-	//add (0.5, 0.5, 0.5) to the coordinate of the moving item to measure from the center of the space
-	var origin = movingItem.coordinate.add(new Point(0.5, 0.5, 0.5));
+	//add half the moving item's size to the coordinate of the moving item to measure from the center of the item
+	var origin = movingItem.coordinate.add(movingItem.size.divide(2));
 	var movementRay = new Ray(origin.toVector(direction));
 	//apply some filter to the map items
 	_.each(map.items, function(item) {

--- a/domain/map.js
+++ b/domain/map.js
@@ -62,8 +62,8 @@ Map.prototype.move = function(movingItem, direction, pushed) {
 	
 	function gravity() {
 		var stop = false;
-		//add (0.5, 0.5, 0.5) to the coordinate of the moving item to measure from the center of the space
-		var origin = movingItem.coordinate.add(new Point(0.5, 0.5, 0.5));
+		//add half the moving item's size to the coordinate of the moving item to measure from the center of the item
+		var origin = movingItem.coordinate.add(movingItem.size.divide(2));
 		var movementRay = new Ray(origin.toVector(heading.down));
 		//apply some filter to the map items
 		_.each(map.items, function(item) {

--- a/domain/map.js
+++ b/domain/map.js
@@ -113,8 +113,12 @@ Map.prototype.intersect = function(ray, cube) {
         maxTimeToIntersect = maxTimeToZIntersect;
 	
 	//a value of < 0 or > 1 indicates that the collision happens outside of the length of the Ray
-	if ((minTimeToIntersect > 0 && minTimeToIntersect < 1) || (maxTimeToIntersect > 0 && maxTimeToIntersect < 1)) {
+	if (minTimeToIntersect >= 0 && minTimeToIntersect <= 1) {
 		return true;
+	}
+	else if (maxTimeToIntersect >= 0 && maxTimeToIntersect <= 1) {
+		//indicates that the ray begins within the cube
+		return false;
 	}
 	else {
 		return false;

--- a/tests/domain/BoardElements/pusher.tests.js
+++ b/tests/domain/BoardElements/pusher.tests.js
@@ -1,0 +1,27 @@
+describe ('Pusher', function() {
+	it ('should push the robot one space', function() {
+		var pusher = new Pusher();
+		pusher.coordinate = new Point(0, 0, 0);
+		pusher.heading = heading.south;
+		pusher.activePhases = { '1': true };
+		
+		var floor = new ConcreteBlock();
+		floor.coordinate = new Point(0, 0, 0);
+		floor.size = new Size(2, 2, 0);
+		
+		var robot = new Robot();
+		robot.coordinate = new Point(0, 0, 0);
+		robot.heading = heading.east;	//heading should be irrelevant, test should break if not
+		
+		var map = new Map();
+		map.items.push(pusher);
+		map.items.push(floor);
+		map.items.push(robot);
+		
+		pusher.execute(robot, map, 1);
+		
+		expect(robot.coordinate.x).to.equal(0);
+		expect(robot.coordinate.y).to.equal(1);
+		expect(robot.coordinate.z).to.equal(0);
+	});
+});

--- a/tests/domain/BoardElements/pusher.tests.js
+++ b/tests/domain/BoardElements/pusher.tests.js
@@ -24,4 +24,36 @@ describe ('Pusher', function() {
 		expect(robot.coordinate.y).to.equal(1);
 		expect(robot.coordinate.z).to.equal(0);
 	});
+	
+	it ('should not push two robots', function() {
+		var pusher = new Pusher();
+		pusher.coordinate = new Point(0, 0, 0);
+		pusher.heading = heading.south;
+		pusher.activePhases = { '1': true };
+		
+		var floor = new ConcreteBlock();
+		floor.coordinate = new Point(0, 0, 0);
+		floor.size = new Size(3, 3, 0);
+		
+		var robot1 = new Robot();
+		robot1.coordinate = new Point(0, 0, 0);
+		robot1.heading = heading.east;
+		
+		var robot2 = new Robot();
+		robot2.coordinate = new Point(0, 1, 0);
+		robot2.heading = heading.south;
+		
+		var map = new Map();
+		map.items.push(pusher);
+		map.items.push(floor);
+		map.items.push(robot1);
+		map.items.push(robot2);
+		
+		expect(robot1.coordinate.x).to.equal(0);
+		expect(robot1.coordinate.y).to.equal(0);
+		expect(robot1.coordinate.z).to.equal(0);
+		expect(robot2.coordinate.x).to.equal(0);
+		expect(robot2.coordinate.y).to.equal(1);
+		expect(robot2.coordinate.z).to.equal(0);
+	});
 });

--- a/tests/domain/BoardElements/pusher.tests.js
+++ b/tests/domain/BoardElements/pusher.tests.js
@@ -2,7 +2,7 @@ describe ('Pusher', function() {
 	it ('should push the robot one space', function() {
 		var pusher = new Pusher();
 		pusher.coordinate = new Point(0, 0, 0);
-		pusher.heading = heading.south;
+		pusher.setHeading(heading.south);
 		pusher.activePhases = { '1': true };
 		
 		var floor = new ConcreteBlock();
@@ -28,7 +28,7 @@ describe ('Pusher', function() {
 	it ('should not push two robots', function() {
 		var pusher = new Pusher();
 		pusher.coordinate = new Point(0, 0, 0);
-		pusher.heading = heading.south;
+		pusher.setHeading(heading.south);
 		pusher.activePhases = { '1': true };
 		
 		var floor = new ConcreteBlock();


### PR DESCRIPTION
Created a pusher board element. Map.move now measures the movement ray from the center of the moving object instead of arbitrarily adding (0.5, 0.5, 0.5) (which would be the center of a robot). Temporarily disabled collisions for moving out of another object. (this is only useful for objects like clouds. We'll have to find some way to handle that if we add clouds. In the meantime, it was causing some strange behaviors with gravity checks)
